### PR TITLE
feat: implement logout API route

### DIFF
--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,34 @@
+import { deleteSession } from "@/src/features/auth/libs/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { success } from "zod";
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionToken = request.cookies.get("sessionToken")?.value;
+
+    if (sessionToken) {
+      await deleteSession({
+        token: sessionToken,
+      });
+    }
+
+    const response = NextResponse.json({
+      success: true,
+      message: "Logged out successfully",
+    });
+    response.cookies.set("sessionToken", "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      expires: new Date(0), // Expire the cookie immediately
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Logout error:", error);
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,7 +1,5 @@
 import { deleteSession } from "@/src/features/auth/libs/auth";
 import { NextRequest, NextResponse } from "next/server";
-import { success } from "zod";
-
 export async function POST(request: NextRequest) {
   try {
     const sessionToken = request.cookies.get("sessionToken")?.value;


### PR DESCRIPTION
This PR implements a logout API route that handles user session termination by deleting the session from storage and clearing the session cookie.

Adds a POST endpoint at /api/logout to handle logout requests
Implements session deletion and cookie clearing functionality
Includes error handling for logout failures